### PR TITLE
Fix replace.js behaviour on Windows

### DIFF
--- a/lib/replace.js
+++ b/lib/replace.js
@@ -28,6 +28,9 @@ Replace.prototype.run = function() {
         dirName = path.dirname(fileName) + path.sep + url;
         url = path.relative(rootFull, dirName);
 
+        if(/^win/.test(process.platform)){
+          url = url.replace("\\", "/");
+        }
         return 'url("' + url + '")';
       });
     }


### PR DESCRIPTION
Current behaviour breaks CSS paths by printing backslashes instead of slashes.
This fixes for me.